### PR TITLE
Update base image to alpine3.15 and Go 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4-alpine3.13 as builder
+FROM golang:1.18.2-alpine3.15 as builder
 RUN apk add git
 
 WORKDIR /build
@@ -10,7 +10,7 @@ COPY cmd cmd/
 
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" ./cmd/runner
 
-FROM alpine:3.13
+FROM alpine:3.15
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 COPY --from=builder /build/runner /
 RUN touch .env

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Storytel/fastly-stackdriver-exporter
 
-go 1.16
+go 1.18
 
 require (
 	cloud.google.com/go v0.82.0
@@ -11,4 +11,24 @@ require (
 	google.golang.org/genproto v0.0.0-20210524171403-669157292da3
 	google.golang.org/grpc v1.37.1
 	google.golang.org/protobuf v1.26.0
+)
+
+require (
+	github.com/ajg/form v0.0.0-20160802194845-cc2954064ec9 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/jsonapi v0.0.0-20201022225600-f822737867f6 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/hashicorp/go-cleanhttp v0.0.0-20170211013415-3573b8b52aa7 // indirect
+	github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 // indirect
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/api v0.46.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 )


### PR DESCRIPTION
To avoid known vulnerabilities as reported in
[Storytel vulnerability report][1]

[1]: https://s.storytel.net/vulns