### PR TITLE
Update Hit Ratio calculation

### DIFF
--- a/fastly.go
+++ b/fastly.go
@@ -111,7 +111,7 @@ func (f *FastlyStatsProvider) mean(list []*fastly.RealtimeData) *FastlyMeanStats
 	}
 
 	// Hit Ratio is not set in RT API, build it synthetically
-	stats.HitRatio = float64(stats.Hits) / float64(stats.Requests)
+	stats.HitRatio = float64(stats.Hits) / float64(stats.Hits+stats.Miss)
 
 	return &FastlyMeanStats{
 		IntervalStart: min,


### PR DESCRIPTION
Hit Ratio is not part of the [Fastly Metrics RT API][1] so we calculate
it. Using `Requests` as denominator includes any client errors as well
which can make it seem like the hit ratio is dropping even though
there's just invalid client requests (e.g. a bot scraping for
vulnerabilities).

Fastly defines the hit ratio as `hits / (hits + misses)` which provides
for a more accurate hit ratio calculation.

[1]: https://developer.fastly.com/reference/api/metrics-stats/realtime/